### PR TITLE
Configurable inference device, use MPS on mac

### DIFF
--- a/rlgym_ppo/ppo/discrete_policy.py
+++ b/rlgym_ppo/ppo/discrete_policy.py
@@ -17,6 +17,8 @@ class DiscreteFF(nn.Module):
     def __init__(self, input_shape, n_actions, layer_sizes, device):
         super().__init__()
         self.device = device
+        self.input_shape = input_shape
+        self.layer_sizes = layer_sizes
 
         assert len(layer_sizes) != 0, "AT LEAST ONE LAYER MUST BE SPECIFIED TO BUILD THE NEURAL NETWORK!"
         layers = [nn.Linear(input_shape, layer_sizes[0]), nn.ReLU()]
@@ -32,6 +34,14 @@ class DiscreteFF(nn.Module):
 
         self.n_actions = n_actions
 
+    def clone(self, to: str = None):
+        device = self.device if to is None else to
+        cloned_policy = DiscreteFF(self.input_shape, self.n_actions, self.layer_sizes, device)
+        cloned_policy.load_state_dict(self.state_dict())
+        if to is not None:
+            cloned_policy.to(to)
+        
+        return cloned_policy
     def get_output(self, obs):
         t = type(obs)
         if t != torch.Tensor:

--- a/rlgym_ppo/ppo/multi_discrete_policy.py
+++ b/rlgym_ppo/ppo/multi_discrete_policy.py
@@ -17,6 +17,7 @@ class MultiDiscreteFF(nn.Module):
     def __init__(self, input_shape, layer_sizes, device):
         super().__init__()
         self.device = device
+        self.layer_sizes = layer_sizes
         bins = [3,3,3,3,3,2,2,2]
         n_output_nodes = sum(bins)
         assert len(layer_sizes) != 0, "AT LEAST ONE LAYER MUST BE SPECIFIED TO BUILD THE NEURAL NETWORK!"
@@ -32,6 +33,13 @@ class MultiDiscreteFF(nn.Module):
         self.model = nn.Sequential(*layers).to(self.device)
         self.splits = bins
         self.multi_discrete = torch_functions.MultiDiscreteRolv(bins)
+
+    def clone(self, to: str = None):
+        device = self.device if to is None else to
+        cloned_policy = MultiDiscreteFF(self.input_shape, self.layer_sizes, device)
+        cloned_policy.load_state_dict(self.state_dict())
+        if to is not None:
+            cloned_policy.to(to)
 
     def get_output(self, obs):
         t = type(obs)

--- a/rlgym_ppo/ppo/value_estimator.py
+++ b/rlgym_ppo/ppo/value_estimator.py
@@ -13,6 +13,8 @@ import numpy as np
 class ValueEstimator(nn.Module):
     def __init__(self, input_shape, layer_sizes, device):
         super().__init__()
+        self.input_shape = input_shape
+        self.layer_sizes = layer_sizes
         self.device = device
 
         assert len(layer_sizes) != 0, "AT LEAST ONE LAYER MUST BE SPECIFIED TO BUILD THE NEURAL NETWORK!"
@@ -26,6 +28,14 @@ class ValueEstimator(nn.Module):
 
         layers.append(nn.Linear(layer_sizes[-1], 1))
         self.model = nn.Sequential(*layers).to(self.device)
+    
+    
+    def clone(self, to: str = None):
+        device = self.device if to is None else to
+        cloned_value_estimator = ValueEstimator(self.input_shape, self.layer_sizes, device)
+        cloned_value_estimator.load_state_dict(self.state_dict())
+        if to is not None:
+            cloned_value_estimator.to(to)
 
     def forward(self, x):
         t = type(x)


### PR DESCRIPTION
Adds an `inference_device` field to the `Learner` class's constructor.

Attempts to use the `"mps"` device on mac for backprop when `"auto"` or `"gpu"` are used as the value of `device` argument.

When the value `"auto"` is specified for the `inference_device` argument, the behaviour varies based on the available hardware. On systems with multiple CUDA devices, `"cuda:1"` is used. On systems with only one CUDA device, `"cuda:0"` is used. On macs with MPS support, `"cpu"` is used, as it's much faster to use `"cpu"` for inference and `"mps"` for backprop.

When the value of `"gpu"` is specified for the `inference_device` argument, the behaviour is the same as `"auto"` for CUDA systems, but on mac, `"mps"` is used, even though this doesn't perform as well, as the user is explicitly asking for the GPU device.

Finally, if the user explicitly specifies a torch device identifier in the `inference_device` argument, that device will be used.

To enable use of a separate inference device, this commit also adds a clone method to all of the model types in the PPO directory. Adding this for the `ValueEstimator` wasn't necessary for this change, but I did it anyway for consistency.

I also added a `get_actions_no_grad` method to each of the policy types for use during inference, as this seemed to speed things up slightly.