### PR TITLE
Allow for chaning number of agents in batched agent and manager

### DIFF
--- a/rlgym_ppo/batched_agents/batched_agent.py
+++ b/rlgym_ppo/batched_agents/batched_agent.py
@@ -31,6 +31,7 @@ def batched_agent_process(proc_id, endpoint, shm_buffer, shm_offset, shm_size, s
     env = None
     metrics_encoding_function = None
     shm_view = None
+    shm_shapes = None
 
     POLICY_ACTIONS_HEADER = comm_consts.POLICY_ACTIONS_HEADER
     ENV_SHAPES_HEADER = comm_consts.ENV_SHAPES_HEADER
@@ -138,7 +139,8 @@ def batched_agent_process(proc_id, endpoint, shm_buffer, shm_offset, shm_size, s
                     metrics = np.empty(shape=(0,))
                     metrics_shape = []
 
-                if shm_view is None:
+                if shm_view is None or shm_shapes != (prev_n_agents, n_agents):
+                    shm_shapes = (prev_n_agents, n_agents)
                     count = 5 + len(metrics_shape) + len(state_shape) + len(rew) + metrics.size + obs.size
                     assert(count <= shm_size), "ATTEMPTED TO CREATE AGENT MESSAGE BUFFER LARGER THAN MAXIMUM ALLOWED SIZE"
                     shm_view = np.frombuffer(buffer=shm_buffer, dtype=np.float32, offset=shm_offset, count=count)

--- a/rlgym_ppo/batched_agents/batched_agent_manager.py
+++ b/rlgym_ppo/batched_agents/batched_agent_manager.py
@@ -289,8 +289,8 @@ class BatchedAgentManager(object):
         rew_end = rew_start + prev_n_agents
 
         shm_shapes = self.shm_shapes[proc_id]
-        if shm_shapes is None or shm_shapes != (metrics_shape, state_shape):
-            self.shm_shapes[proc_id] = (metrics_shape, state_shape)
+        if shm_shapes is None or shm_shapes != (metrics_shape, state_shape, prev_n_agents):
+            self.shm_shapes[proc_id] = (metrics_shape, state_shape, prev_n_agents)
             rews = np.reshape(shm_view[rew_start : rew_end], (rew_end - rew_start,))
             metrics = np.reshape(shm_view[rew_end : rew_end + n_metrics], metrics_shape)
             obs = np.reshape(shm_view[rew_end + n_metrics : rew_end + n_metrics + prod(state_shape)], state_shape)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 with open('README.md', 'r') as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Some variables are not being updated when the number of agents changes, preventing the use of an rlgym environment that varies the game size. This PR fixes that and allows them to run.

Attached is a patch to `rlgym_v2_example.py` that reproduces the error.
[var_num_agents.patch](https://github.com/AechPro/rlgym-ppo/files/14071141/var_num_agents.patch)
