### PR TITLE
Add collision mesh files, wandb folder, and data folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,9 @@ rlgym-ppo.code-workspace
 
 # RocketSim collision meshes
 *.cmf
+
+# wandb folder
+wandb/
+
+# Run data folder
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ cython_debug/
 rlgym-ppo.code-workspace
 .vscode/settings.json
 *.code-workspace
+
+# RocketSim collision meshes
+*.cmf


### PR DESCRIPTION
I don't think any of these need to be tracked by git, especially collision mesh files.