### PR TITLE
Add delta time compensation to render delay

### DIFF
--- a/rlgym_ppo/batched_agents/batched_agent.py
+++ b/rlgym_ppo/batched_agents/batched_agent.py
@@ -95,6 +95,7 @@ def batched_agent_process(proc_id, endpoint, shm_buffer, shm_offset, shm_size, s
 
     # Primary interaction loop.
     try:
+        last_render_time = time.time()
         while True:
             message_bytes = pipe.recv(4096)
             message = frombuffer(message_bytes, dtype=np.float32)
@@ -167,8 +168,13 @@ def batched_agent_process(proc_id, endpoint, shm_buffer, shm_offset, shm_size, s
                 if render:
                     env.render()
                     if render_delay is not None:
-                        time.sleep(render_delay / get_game_speed())
+                        render_delta_time = time.time() - last_render_time
 
+                        target_delay = render_delay / get_game_speed()
+                        time.sleep(max(0, target_delay - render_delta_time))
+
+                        last_render_time = time.time()
+                        
                     while get_game_paused():
                         time.sleep(0.1)
 


### PR DESCRIPTION
This is a small addition that compensates for the time it takes to step and send to the renderer in the render delay, such that the interval between rendering is far more accurate to the chosen delay.

In the second commit, I used a persistent compensation time which is updated from the timing error to further improve the accuracy (accuracy being measured as the difference between actual render interval and `render_delay`). This should compensate for everything, including the poor accuracy of the sleep method (probably a Windows thing).
To print the true delta time between renders, add `print(render_delta_time)` before the `sleep_delay = ...` line. 