### PR TITLE
Fix value function loss not being divided by minibatch amount

### DIFF
--- a/rlgym_ppo/ppo/ppo_learner.py
+++ b/rlgym_ppo/ppo/ppo_learner.py
@@ -172,12 +172,9 @@ class PPOLearner(object):
                     policy_loss = -torch.min(
                         ratio * advantages, clipped * advantages
                     ).mean()
-                    value_loss = self.value_loss_fn(vals, target_values)
-                    ppo_loss = (
-                        (policy_loss - entropy * self.ent_coef)
-                        * self.mini_batch_size
-                        / self.batch_size
-                    )
+                    minibatch_ratio = self.mini_batch_size / self.batch_size
+                    value_loss = self.value_loss_fn(vals, target_values) * minibatch_ratio
+                    ppo_loss = (policy_loss - entropy * self.ent_coef) * minibatch_ratio
 
                     ppo_loss.backward()
                     value_loss.backward()


### PR DESCRIPTION
This fixes a bug where the value function's loss was not being scaled by the minibatch ratio, meaning value function loss would change with different minibatch sizes.